### PR TITLE
Fix content.opf title alphabetic sort

### DIFF
--- a/src/epub/content.opf
+++ b/src/epub/content.opf
@@ -29,7 +29,7 @@
 		<meta property="schema:accessibilitySummary">This publication conforms to WCAG 2.0 Level AA.</meta>
 		<link href="onix.xml" rel="onix-record"/>
 		<dc:title id="title">Armageddon 2419 A.D.</dc:title>
-		<meta property="file-as" refines="#title">Armageddon 2519 A.D.</meta>
+		<meta property="file-as" refines="#title">Armageddon 2419 A.D.</meta>
 		<dc:subject id="subject-1">Science fiction</dc:subject>
 		<dc:subject id="subject-2">War stories</dc:subject>
 		<meta property="meta-auth" refines="#subject-1">https://www.gutenberg.org/ebooks/32530</meta>


### PR DESCRIPTION
Alphabetic sort for the title wrongly puts 2519 in title, when it should be 2419.